### PR TITLE
Handle broadcast sink connect message correctly

### DIFF
--- a/app/src/broadcast_assistant.h
+++ b/app/src/broadcast_assistant.h
@@ -14,16 +14,17 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/gap.h>
 
-#define BT_DATA_RSSI        (BT_DATA_MANUFACTURER_DATA - 1)
-#define BT_DATA_SID         (BT_DATA_MANUFACTURER_DATA - 2)
-#define BT_DATA_PA_INTERVAL (BT_DATA_MANUFACTURER_DATA - 3)
-#define BT_DATA_ERROR_CODE  (BT_DATA_MANUFACTURER_DATA - 4)
+#define BT_DATA_RSSI         (BT_DATA_MANUFACTURER_DATA - 1)
+#define BT_DATA_SID          (BT_DATA_MANUFACTURER_DATA - 2)
+#define BT_DATA_PA_INTERVAL  (BT_DATA_MANUFACTURER_DATA - 3)
+#define BT_DATA_ERROR_CODE   (BT_DATA_MANUFACTURER_DATA - 4)
+#define BT_DATA_BROADCAST_ID (BT_DATA_MANUFACTURER_DATA - 5)
 
 int scan_for_broadcast_source(uint8_t seq_no);
 int scan_for_broadcast_sink(uint8_t seq_no);
-int stop_scanning();
+int stop_scanning(void);
 int connect_to_sink(uint8_t seq_no, uint16_t msg_length, uint8_t *payload);
 int broadcast_assistant_init(void);
-int disconnect_unpair_all();
+int disconnect_unpair_all(void);
 
 #endif /* __BROADCAST_ASSISTANT_H__ */

--- a/app/src/message_handler.c
+++ b/app/src/message_handler.c
@@ -17,7 +17,7 @@
 #include "broadcast_assistant.h"
 #include "message_handler.h"
 
-LOG_MODULE_REGISTER(command, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(message_handler, LOG_LEVEL_DBG);
 
 #define HEARTBEAT_ON 1
 
@@ -26,7 +26,7 @@ static K_SEM_DEFINE(webusb_msg_sem, 1, 1);
 static void heartbeat_timeout_handler(struct k_timer *dummy_p);
 K_TIMER_DEFINE(heartbeat_timer, heartbeat_timeout_handler, NULL);
 
-static void send_response(enum message_sub_type type, uint8_t seq_no, int32_t rc);
+static void send_simple_message(enum message_type mtype, enum message_sub_type stype, uint8_t seq_no, int32_t rc);
 
 static struct webusb_message webusb_msg;
 
@@ -41,17 +41,17 @@ static void heartbeat_timeout_handler(struct k_timer *timer)
 	}
 }
 
-static void send_response(enum message_sub_type type, uint8_t seq_no, int32_t rc)
+static void send_simple_message(enum message_type mtype, enum message_sub_type stype, uint8_t seq_no, int32_t rc)
 {
 	int ret;
 
-	LOG_INF("send_response(%d, %u, %d)", type, seq_no, rc);
+	LOG_INF("send simple message(%d, %d, %u, %d)", mtype, stype, seq_no, rc);
 
 	k_sem_take(&webusb_msg_sem, K_FOREVER);
 	memset(&webusb_msg, 0, sizeof(struct webusb_message));
 
-	webusb_msg.type = MESSAGE_TYPE_RES;
-	webusb_msg.sub_type = type;
+	webusb_msg.type = mtype;
+	webusb_msg.sub_type = stype;
 	webusb_msg.seq_no = seq_no;
 	webusb_msg.length = 0;
 
@@ -64,34 +64,23 @@ static void send_response(enum message_sub_type type, uint8_t seq_no, int32_t rc
 	ret = webusb_transmit((uint8_t *)&webusb_msg,
 			      webusb_msg.length + offsetof(struct webusb_message, payload));
 	if (ret != 0) {
-		LOG_ERR("Failed to send response (err=%d)", ret);
+		LOG_ERR("Failed to send message (err=%d)", ret);
 	}
 
 	k_sem_give(&webusb_msg_sem);
+
 }
 
-void send_event(enum message_sub_type type)
+void send_response(enum message_sub_type stype, uint8_t seq_no, int32_t rc)
 {
-	int ret;
-
-	LOG_INF("send_event(%d)", type);
-
-	k_sem_take(&webusb_msg_sem, K_FOREVER);
-	memset(&webusb_msg, 0, sizeof(struct webusb_message));
-
-	webusb_msg.type = MESSAGE_TYPE_EVT;
-	webusb_msg.sub_type = type;
-	webusb_msg.seq_no = 0;
-	webusb_msg.length = 0;
-
-	ret = webusb_transmit((uint8_t *)&webusb_msg,
-			      webusb_msg.length + offsetof(struct webusb_message, payload));
-	if (ret != 0) {
-		LOG_ERR("Failed to send response (err=%d)", ret);
-	}
-
-	k_sem_give(&webusb_msg_sem);
+	send_simple_message(MESSAGE_TYPE_RES, stype, seq_no, rc);
 }
+
+void send_event(enum message_sub_type stype, int32_t rc)
+{
+	send_simple_message(MESSAGE_TYPE_EVT, stype, 0, rc);
+}
+
 
 void message_handler(struct webusb_message *msg_ptr, uint16_t msg_length)
 {

--- a/app/src/message_handler.h
+++ b/app/src/message_handler.h
@@ -47,7 +47,8 @@ struct webusb_message {
 	uint8_t payload[MAX_MSG_PAYLOAD_LEN];
 } __packed;
 
-void send_event(enum message_sub_type type);
+void send_response(enum message_sub_type stype, uint8_t seq_no, int32_t rc);
+void send_event(enum message_sub_type stype, int32_t rc);
 void message_handler(struct webusb_message *msg_ptr, uint16_t msg_length);
 void message_handler_init(void);
 


### PR DESCRIPTION
Broadcast connect message from the webusb is handled in the following sequence (succesful case):
stop_scan, create_connection, connected_cb, bap_discover, discover_cb, restart_scan.
Connect / disconnect / scan events are sent including error codes. Broadcast ID added for broadcast source found message.