### PR TITLE
When a sink disconnects, also remove it from the model sink list. As

### DIFF
--- a/web/models/assistant-model.js
+++ b/web/models/assistant-model.js
@@ -256,7 +256,7 @@ export class AssistantModel extends EventTarget {
 					sink.state = "connected";
 					this.dispatchEvent(new CustomEvent('sink-updated', {detail: { sink }}));
 				} else {
-					sink.state = "";
+					this.#sinks.splice(this.#sinks.indexOf(sink, 1));
 					this.dispatchEvent(new CustomEvent('sink-disconnected', {detail: { sink }}));
 				}
 			}


### PR DESCRIPTION
the element was removed only in sink-device-list this caused a bug where when a sink was disconnected, yet still advertising and re-scanned it would send "sink updated" when found, instead of "sink found". The device list would then only answer with "not found"